### PR TITLE
Set locale for correct dates

### DIFF
--- a/mt-wp-plugin.php
+++ b/mt-wp-plugin.php
@@ -13,7 +13,7 @@ Text Domain: mt-wp-plugin
 /*
  * Set locale for correct dates
  */
-setlocale(LC_ALL, get_locale().'.'.get_bloginfo('charset'), get_locale());
+setlocale(LC_ALL, get_locale());
 
 /*
  * Set timezone


### PR DESCRIPTION
The function 'get_bloginfo' returns 'UTF-8' while the encoding
is called 'utf8' (its suffix). Only getting the local is fine
because 'utf8_encode' is used everywher.